### PR TITLE
fix: add permissions for language-specific Overleaf domains

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -18,7 +18,8 @@
         "options.html"
       ],
       "matches": [
-        "https://www.overleaf.com/*"
+        "https://www.overleaf.com/*",
+        "https://www.*.overleaf.com/*"
       ]
     }
   ],
@@ -36,7 +37,8 @@
     {
       "world": "MAIN",
       "matches": [
-        "https://www.overleaf.com/project/*"
+        "https://www.overleaf.com/project/*",
+        "https://www.*.overleaf.com/project/*"
       ],
       "run_at": "document_idle",
       "js": [
@@ -45,7 +47,8 @@
     },
     {
       "matches": [
-        "https://www.overleaf.com/project/*"
+        "https://www.overleaf.com/project/*",
+        "https://www.*.overleaf.com/project/*"
       ],
       "run_at": "document_idle",
       "js": [


### PR DESCRIPTION
Adds `https://www.*.overleaf.com/*` match patterns to `web_accessible_resources` and `content_scripts` in the manifest, enabling the extension to work on language-specific domains (e.g. `de.overleaf.com`, `fr.overleaf.com`).

Fixes #38