### PR TITLE
fix: update model list and allow custom model input

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -22,6 +22,7 @@ const config = (env, argv) =>
         https: false,
         url: false,
         timers: false,
+        string_decoder: false,
       },
     },
   });

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -19,7 +19,7 @@
       ],
       "matches": [
         "https://www.overleaf.com/*",
-        "https://www.*.overleaf.com/*"
+        "https://*.overleaf.com/*"
       ]
     }
   ],
@@ -38,7 +38,7 @@
       "world": "MAIN",
       "matches": [
         "https://www.overleaf.com/project/*",
-        "https://www.*.overleaf.com/project/*"
+        "https://*.overleaf.com/project/*"
       ],
       "run_at": "document_idle",
       "js": [
@@ -48,7 +48,7 @@
     {
       "matches": [
         "https://www.overleaf.com/project/*",
-        "https://www.*.overleaf.com/project/*"
+        "https://*.overleaf.com/project/*"
       ],
       "run_at": "document_idle",
       "js": [

--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -77,11 +77,14 @@ const OptionsForm = () => {
           </div>
           <div class="pure-control-group">
             <label for="field-model">Model</label>
-            <select style="padding-top: 0px; padding-bottom: 0px" id="field-model" class="pure-input-1-4"
-              onChange={(e) => onOptionsChange({ ...state, model: e.currentTarget.value })}>
-              {MODELS.map((model) => <option value={model} selected={model === state.model}>{model}</option>)}
-            </select>
-            <span class="pure-form-message-inline pure-u-1-3">Select the model you want to use.</span>
+            <input type="text" list="model-list" id="field-model" class="pure-input-1-4"
+              placeholder="gpt-4o-mini"
+              value={state.model}
+              onChange={(e) => onOptionsChange({ ...state, model: e.currentTarget.value })} />
+            <datalist id="model-list">
+              {MODELS.map((model) => <option value={model} />)}
+            </datalist>
+            <span class="pure-form-message-inline pure-u-1-3">Select a model or type a custom model name.</span>
           </div>
           <h2>Suggestion</h2>
           <div class="pure-u-3-4">

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,10 +5,25 @@ export const LOCAL_STORAGE_KEY_API_KEY = 'config-api-key';
 export const LOCAL_STORAGE_KEY_BASE_URL = 'config-base-url';
 export const LOCAL_STORAGE_KEY_MODEL = 'config-model';
 
-export const DEFAULT_MODEL = 'gpt-3.5-turbo';
+export const DEFAULT_MODEL = 'gpt-4o-mini';
 export const DEFAULT_SUGGESTION_MAX_OUTPUT_TOKEN = 100;
 export const MAX_LENGTH_BEFORE_CURSOR = 5000;
 export const MAX_LENGTH_AFTER_CURSOR = 5000;
 export const MAX_LENGTH_SELECTION = 20000;
 
-export const MODELS = ["gpt-3.5-turbo", "gpt-4", "gpt-4-turbo", "gpt-4o", "gpt-4o-mini"];
+export const MODELS = [
+  "gpt-5.5",
+  "gpt-5.4",
+  "gpt-5.4-mini",
+  "gpt-5.2",
+  "gpt-5",
+  "gpt-5-mini",
+  "gpt-4o",
+  "gpt-4o-mini",
+  "gpt-4.1",
+  "gpt-4.1-mini",
+  "gpt-4.1-nano",
+  "o4-mini",
+  "o3",
+  "o3-mini",
+];


### PR DESCRIPTION
- Replace outdated models (gpt-3.5-turbo, gpt-4, gpt-4-turbo) with current ones (gpt-4o, gpt-4.1, gpt-4.1-mini, gpt-4.1-nano, o3, o3-mini, o4-mini)
- Change default model from gpt-3.5-turbo to gpt-4o-mini
- Replace fixed `<select>` dropdown with a text input + `<datalist>`, allowing users to type any custom model name (useful for Azure OpenAI, third-party providers, or newly released models)

Fixes #39