### PR TITLE
fix: remove search icon from toolbar popup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "overleaf-copilot",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Copilot for Overleaf",
   "private": true,
   "scripts": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Overleaf Copilot",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Copilot for Overleaf",
   "icons": {
     "16": "icons/icon_16.png",

--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -192,13 +192,6 @@ const OptionsForm = () => {
             <span class="pure-form-message-inline">Add a new custom action to the toolbar.</span>
           </div>
           <div class="pure-controls">
-            <label for="field-search-disabled" class="pure-checkbox">
-              <input type="checkbox" id="field-search-disabled" checked={state.toolbarSearchDisabled}
-                onChange={(e) => onOptionsChange({ ...state, toolbarSearchDisabled: e.currentTarget.checked })} /> Disable Search
-            </label>
-            <span class="pure-form-message-inline pure-u-1-3">Hide the search icon from the toolbar.</span>
-          </div>
-          <div class="pure-controls">
             <label for="field-toolbar-disabled" class="pure-checkbox">
               <input type="checkbox" id="field-toolbar-disabled" checked={state.toolbarDisabled}
                 onChange={(e) => onOptionsChange({ ...state, toolbarDisabled: e.currentTarget.checked })} /> Disable Toolbar

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -8,14 +8,12 @@ import "./styles/Toolbar.css";
 export interface ToolbarProps {
   data: EditorSelectionData;
   actions: ToolbarAction[];
-  searchDisabled: boolean;
   onShowEditor: (action: { name: string, prompt: string, icon: string }) => void;
-  onClickSearch: () => void;
   signal: AbortSignal;
   options: Options;
 }
 
-export const Toolbar = ({ data, actions, searchDisabled, onShowEditor, onClickSearch, signal, options }: ToolbarProps) => {
+export const Toolbar = ({ data, actions, onShowEditor, signal, options }: ToolbarProps) => {
   const [loading, setLoading] = useState(false);
 
   const onClick = async (action: ToolbarAction) => {
@@ -48,8 +46,5 @@ export const Toolbar = ({ data, actions, searchDisabled, onShowEditor, onClickSe
         <Icon name={action.icon} size={16} />
       </div>
     })}
-    {!searchDisabled && <div className="copilot-toolbar-button copilot-toolbar-search" title="Search" onClick={onClickSearch}>
-      <Icon name="search" size={16} />
-    </div>}
   </Fragment>
 }

--- a/src/components/styles/Toolbar.css
+++ b/src/components/styles/Toolbar.css
@@ -16,7 +16,10 @@ div#copilot-toolbar div.copilot-toolbar-button {
   cursor: pointer;
   background-color: rgb(7, 109, 53);
   margin-left: 2px;
-  padding: 2px 5px 5px 5px;
+  padding: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: white;
 
   &:hover {
@@ -28,13 +31,5 @@ div#copilot-toolbar div.copilot-toolbar-button {
     background-color: #999;
     filter: none;
     cursor: not-allowed;
-  }
-}
-
-div#copilot-toolbar div.copilot-toolbar-search {
-  background-color: #3265b2;
-
-  &:hover {
-    background-color: #295392;
   }
 }

--- a/src/components/styles/ToolbarEditor.css
+++ b/src/components/styles/ToolbarEditor.css
@@ -47,7 +47,7 @@ div#copilot-toolbar-editor div.toolbar-editor-header a span {
   }
 
   &:last-child {
-    vertical-align: baseline;
+    vertical-align: middle;
     margin-left: 2px;
   }
 }

--- a/src/components/styles/ToolbarEditor.css
+++ b/src/components/styles/ToolbarEditor.css
@@ -43,7 +43,7 @@ div#copilot-toolbar-editor div.toolbar-editor-header .toolbar-editor-action {
 
 div#copilot-toolbar-editor div.toolbar-editor-header a span {
   &:first-child {
-    vertical-align: middle;
+    vertical-align: baseline;
   }
 
   &:last-child {

--- a/src/iso/toolbar.ts
+++ b/src/iso/toolbar.ts
@@ -36,7 +36,6 @@ export function showToolbar(data: EditorSelectionData, options: Options, signal:
     signal,
     data: data,
     actions: options.toolbarActions ?? [],
-    searchDisabled: !!options.toolbarSearchDisabled,
     onShowEditor: (action) => {
       const toolbar = document.getElementById('copilot-toolbar');
       if (toolbar == null)
@@ -63,9 +62,6 @@ export function showToolbar(data: EditorSelectionData, options: Options, signal:
       document.body.appendChild(toolbarEditor);
       render(h(ToolbarEditor, { action, data, options, signal }), toolbarEditor);
     },
-    onClickSearch: async () => {
-      await onFindSimilar(data.content.selection);
-    }
   }), toolbar);
 }
 


### PR DESCRIPTION
- Remove the search/find-similar button from the toolbar popup
- Fix toolbar icon alignment (icons were shifted down due to asymmetric padding)
- Fix toolbar editor icon alignment
- Fix: use `max_completion_tokens` instead of deprecated `max_tokens` for newer OpenAI models (GPT-5.x, o-series)
- Remove the 'Disable Search' option from settings
- Bump version to 0.2.7