### PR TITLE
fix: use max_completion_tokens instead of max_tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "overleaf-copilot",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Copilot for Overleaf",
   "private": true,
   "scripts": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Overleaf Copilot",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Copilot for Overleaf",
   "icons": {
     "16": "icons/icon_16.png",

--- a/src/utils/suggestion.ts
+++ b/src/utils/suggestion.ts
@@ -54,7 +54,7 @@ export async function* getSuggestion(content: TextContent, signal: AbortSignal, 
     });
 
     try {
-      const stream = await openai.chat.completions.create(
+      const stream: any = await openai.chat.completions.create(
         {
           messages: [
             {
@@ -63,9 +63,9 @@ export async function* getSuggestion(content: TextContent, signal: AbortSignal, 
             },
           ],
           model: options.model ?? DEFAULT_MODEL,
-          max_tokens: options.suggestionMaxOutputToken ?? DEFAULT_SUGGESTION_MAX_OUTPUT_TOKEN,
+          max_completion_tokens: options.suggestionMaxOutputToken ?? DEFAULT_SUGGESTION_MAX_OUTPUT_TOKEN,
           stream: true,
-        },
+        } as any,
         { signal: signal }
       );
 


### PR DESCRIPTION
Newer OpenAI models (GPT-5.x, o-series) no longer support the deprecated `max_tokens` parameter and require `max_completion_tokens` instead.

Fixes the error:
```
400 Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.
```